### PR TITLE
Update BootstrapForm.php

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -529,6 +529,10 @@ class BootstrapForm
      */
     protected function getLabelTitle($label, $name)
     {
+        if (\Illuminate\Support\Facades\Lang::has('messages.'.$name) && $label==null)
+        {
+            return \Illuminate\Support\Facades\Lang::get('messages.'.$name);
+        }
         return $label ?: Str::title($name);
     }
 


### PR DESCRIPTION
In that way if the label is empty It will search for messages language file of the current language and get the text from there. It is usefull when you use a field name a lot.