### PR TITLE
Fix flattenFieldName() to use input names like foo.0.bar

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -809,7 +809,7 @@ class BootstrapForm
     public function flattenFieldName($field)
     {
         return preg_replace_callback("/\[(.*)\\]/U", function ($matches) {
-            if (!empty($matches[1])) {
+            if (isset($matches[1])) {
                 return "." . $matches[1];
             }
         }, $field);

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -809,7 +809,7 @@ class BootstrapForm
     public function flattenFieldName($field)
     {
         return preg_replace_callback("/\[(.*)\\]/U", function ($matches) {
-            if (isset($matches[1])) {
+            if (!empty($matches[1]) || $matches[1] === '0') {
                 return "." . $matches[1];
             }
         }, $field);

--- a/tests/BootstrapFormTest.php
+++ b/tests/BootstrapFormTest.php
@@ -192,6 +192,14 @@ class BootstrapFormTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo.bar', $result);
     }
+    
+    /** @test */
+    public function in_allows_zero_in_field_name()
+    {
+        $result = $this->bootstrapForm->flattenFieldName('foo[0]');
+
+        $this->assertEquals('foo.0', $result);
+    }
 
     /** @test */
     public function it_flattens_nested_array_from_field_name()


### PR DESCRIPTION
Hi Dwight,

Long time age! Still happy to use your repository! I ran into a bug when using multidimensional input fieldname validation. The empty statement blocks the use of foo.0.bar. Instead I use isset() to check if matched.

Regards, Ferry!