### PR TITLE
allow url to be generated outside BootstrapForm class

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -142,6 +142,19 @@ class BootstrapForm
     {
         $model = $options['model'];
 
+        // This code lets us generate the url outside BootstrapForm class
+        // The Bootform will accept any kind of url
+        
+        /*Ex: {!! BootForm::horizontal(['model' => $user
+        , 'url' => route('admin.advertisers.users.create'
+        , ['advertisers' => $advertiser->id]), 'method' => 'POST']) !!}*/
+
+        if (isset($options['url'])) {
+            array_forget($options, ['update', 'store']);
+            $options['method'] = isset($options['method']) ? $options['method'] : 'GET' ;
+            return $this->form->model($model, $options);
+        }
+
         // If the form is passed a model, we'll use the update route to update
         // the model using the PUT method.
         if (!is_null($options['model']) && $options['model']->exists) {


### PR DESCRIPTION
This is an exaple: {!! BootForm::horizontal(['model' => $, 'url' => route('admin.advertisers.users.create', ['advertisers' => $advertiser->id]), 'method' => 'POST']) !!}