### PR TITLE
No label Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ BootForm::submit('Login');
 BootForm::close();
 ```
 
+### Hide Labels
+
+You may hide an element's label by setting the the value to `false`.
+
+```php
+// An input with no label.
+BootForm::text('username', false);
+```
+
 ### Help Text
 
 You may pass a `help_text` option to any field to have [Bootstrap Help Text](https://getbootstrap.com/css/#forms-help-text) appended to the rendered form group.

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -579,6 +579,11 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
+
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 
@@ -628,6 +633,8 @@ class BootstrapForm
      */
     protected function getLabelTitle($label, $name)
     {
+        if (is_bool($label) && $label == false) return false;
+
         if (is_null($label) && Lang::has("forms.{$name}")) {
             return Lang::get("forms.{$name}");
         }

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -228,6 +228,10 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 
@@ -572,6 +576,10 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 
@@ -636,6 +644,10 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -228,11 +228,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -363,7 +359,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        return $this->getFormGroup(null, $wrapperElement);
+        return $this->getFormGroup(null, false, $wrapperElement);
     }
 
     /**
@@ -417,11 +413,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $elements . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -441,7 +433,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . '</div>';
 
-        return $this->getFormGroup(null, $wrapperElement);
+        return $this->getFormGroup(null, false, $wrapperElement);
     }
 
     /**
@@ -496,11 +488,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $elements . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -534,7 +522,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>'. $inputElement . '</div>';
 
-        return $this->getFormGroup(null, $wrapperElement);
+        return $this->getFormGroup(null, false, $wrapperElement);
     }
 
     /**
@@ -553,7 +541,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>'. $inputElement . '</div>';
 
-        return $this->getFormGroup(null, $wrapperElement);
+        return $this->getFormGroup(null, false, $wrapperElement);
     }
 
     /**
@@ -576,11 +564,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -603,12 +587,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -644,11 +623,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $this->getFormGroup($name, $wrapperElement);
-        }
-        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
+        return $this->getFormGroup($name, $label, $wrapperElement);
     }
 
     /**
@@ -671,6 +646,20 @@ class BootstrapForm
     }
 
     /**
+     * Get a form group comprised of a form element and errors.
+     *
+     * @param  string  $name
+     * @param  string  $element
+     * @return string
+     */
+    protected function getFormGroupWithoutLabel($name, $element)
+    {
+        $options = $this->getFormGroupOptions($name);
+
+        return '<div' . $this->html->attributes($options) . '>' . $element . '</div>';
+    }
+
+    /**
      * Get a form group comprised of a label, form element and errors.
      *
      * @param  string  $name
@@ -686,17 +675,20 @@ class BootstrapForm
     }
 
     /**
-     * Get a form group.
+     * Get a form group with or without a label.
      *
      * @param  string  $name
+     * @param  string  $label
      * @param  string  $element
      * @return string
      */
-    public function getFormGroup($name = null, $element)
+    public function getFormGroup($name = null, $label = null, $wrapperElement)
     {
-        $options = $this->getFormGroupOptions($name);
-
-        return '<div' . $this->html->attributes($options) . '>' . $element . '</div>';
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroupWithoutLabel($name, $wrapperElement);
+        }
+        return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 
     /**

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -377,15 +377,12 @@ class BootstrapForm
     {
         $label = $this->getLabelTitle($label, $name);
 
-        $labelOptions = $inline ? ['class' => 'checkbox-inline'] : [];
+        if (is_bool($label) && $label == false ) $label = '';
 
+        $labelOptions = $inline ? ['class' => 'checkbox-inline'] : [];
         $inputElement = $this->form->checkbox($name, $value, $checked, $options);
         $labelElement = '<label ' . $this->html->attributes($labelOptions) . '>' . $inputElement . $label . '</label>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $inline ? $inputElement : '<div class="checkbox">' . $inputElement . '</div>';
-        }
         return $inline ? $labelElement : '<div class="checkbox">' . $labelElement . '</div>';
     }
 
@@ -450,6 +447,9 @@ class BootstrapForm
     public function radioElement($name, $label = null, $value = null, $checked = null, $inline = false, array $options = [])
     {
         $label = $this->getLabelTitle($label, $name);
+
+        if (is_bool($label) && $label == false ) $label = '';
+
         $Value = $value ?: $label;
 
         $labelOptions = $inline ? ['class' => 'radio-inline'] : [];
@@ -457,10 +457,6 @@ class BootstrapForm
         $inputElement = $this->form->radio($name, $value, $checked, $options);
         $labelElement = '<label ' . $this->html->attributes($labelOptions) . '>' . $inputElement . $label . '</label>';
 
-        if (is_bool($label) && $label == false )
-        {
-            return $inline ? $inputElement : '<div class="radio">' . $inputElement . '</div>';
-        }
         return $inline ? $labelElement : '<div class="radio">' . $labelElement . '</div>';
     }
 

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -382,6 +382,10 @@ class BootstrapForm
         $inputElement = $this->form->checkbox($name, $value, $checked, $options);
         $labelElement = '<label ' . $this->html->attributes($labelOptions) . '>' . $inputElement . $label . '</label>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $inline ? $inputElement : '<div class="checkbox">' . $inputElement . '</div>';
+        }
         return $inline ? $labelElement : '<div class="checkbox">' . $labelElement . '</div>';
     }
 
@@ -409,6 +413,10 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $elements . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 
@@ -453,6 +461,10 @@ class BootstrapForm
         $inputElement = $this->form->radio($name, $value, $checked, $options);
         $labelElement = '<label ' . $this->html->attributes($labelOptions) . '>' . $inputElement . $label . '</label>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $inline ? $inputElement : '<div class="radio">' . $inputElement . '</div>';
+        }
         return $inline ? $labelElement : '<div class="radio">' . $labelElement . '</div>';
     }
 
@@ -480,6 +492,10 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $elements . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
+        if (is_bool($label) && $label == false )
+        {
+            return $this->getFormGroup($name, $wrapperElement);
+        }
         return $this->getFormGroupWithLabel($name, $label, $wrapperElement);
     }
 


### PR DESCRIPTION
Added ability to generate elements with no label by setting `label` to `false`.
Eg: `BootForm::text('username', false);`

**Preview:**
![screen shot 2016-10-23 at 15 46 53](https://cloud.githubusercontent.com/assets/4448928/19627135/fcc35c5c-9937-11e6-8fa9-9f95d96d0540.png)
