### PR TITLE
Fix Radio Boxes with value of zero

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -446,7 +446,7 @@ class BootstrapForm
     {
         $label = $label === false ? null : $this->getLabelTitle($label, $name);
 
-        $value = !$value && $value != 0 ? $label : $value;
+        $value = is_null($value) ? $label : $value;
 
         $labelOptions = $inline ? ['class' => 'radio-inline'] : [];
 

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -446,7 +446,7 @@ class BootstrapForm
     {
         $label = $label === false ? null : $this->getLabelTitle($label, $name);
 
-        $value = $value ?: $label;
+        $value = !$value && $value != 0 ? $label : $value;
 
         $labelOptions = $inline ? ['class' => 'radio-inline'] : [];
 


### PR DESCRIPTION
This is to check if the value of a radio box is zero to accept it as a value and not use the label for value, only use label for value when no value is set and the value is not zero