### PR TITLE
fix for checkbox - removing second label

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -359,7 +359,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        return $this->getFormGroup(null, $label, $wrapperElement);
+        return $this->getFormGroup(null, null, $wrapperElement);
     }
 
     /**


### PR DESCRIPTION
Removes "heading" label on a checkbox - fixes a bug where 2 labels are generated for a checkbox.