### PR TITLE
Make possible to add HTML code inside a label

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,24 @@ BootForm::submit('Login');
 BootForm::close();
 ```
 
-### Hide Labels
+### Labels
+
+#### Hide Labels
 
 You may hide an element's label by setting the the value to `false`.
 
 ```php
 // An input with no label.
 BootForm::text('username', false);
+```
+
+#### Labels with HTML
+
+To include HTML code inside a label, instead of passing a text just pass a array with key `html` and the text:
+
+```php
+// A label with HTML code
+BootForm::text('username', ['html' => 'Username <span class="required">*</span>']);
 ```
 
 ### Help Text

--- a/README.md
+++ b/README.md
@@ -223,11 +223,14 @@ BootForm::text('username', false);
 
 #### Labels with HTML
 
-To include HTML code inside a label, instead of passing a text just pass a array with key `html` and the text:
+To include HTML code inside a label:
 
 ```php
-// A label with HTML code
+// A label with HTML code using array notation
 BootForm::text('username', ['html' => 'Username <span class="required">*</span>']);
+
+// A label with HTML code using HtmlString object
+BootForm::text('username', new Illuminate\Support\HtmlString('Username <span class="required">*</span>'));
 ```
 
 ### Help Text

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -521,8 +521,14 @@ class BootstrapForm
     public function label($name, $value = null, array $options = [])
     {
         $options = $this->getLabelOptions($options);
+        $escapeHtml = true;
 
-        return $this->form->label($name, $value, $options);
+        if (is_array($value) and isset($value['html'])) {
+            $escapeHtml = false;
+            $value = $value['html'];
+        }
+
+        return $this->form->label($name, $value, $options, $escapeHtml);
     }
 
     /**

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -6,6 +6,7 @@ use Collective\Html\FormBuilder;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Session\SessionManager as Session;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Lang;
 
@@ -521,11 +522,15 @@ class BootstrapForm
     public function label($name, $value = null, array $options = [])
     {
         $options = $this->getLabelOptions($options);
-        $escapeHtml = true;
+
+        $escapeHtml = false;
 
         if (is_array($value) and isset($value['html'])) {
-            $escapeHtml = false;
             $value = $value['html'];
+        } elseif ($value instanceof HtmlString) {
+            $value = $value->toHtml();
+        } else {
+            $escapeHtml = true;
         }
 
         return $this->form->label($name, $value, $options, $escapeHtml);


### PR DESCRIPTION
For now all labels are escaped. This allow us to include HTML code inside it without escaping:

```php
// A label with HTML code using array notation
BootForm::text('username', ['html' => 'Username <span class="required">*</span>']);

// A label with HTML code using HtmlString object
BootForm::text('username', new Illuminate\Support\HtmlString('Username <span class="required">*</span>'));
```

This fix #72 both using `HtmlString` object and `array`.