### PR TITLE
Fixing issue with model dumped in form attributes

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -156,7 +156,7 @@ class BootstrapForm
 
         if (isset($options['url'])) {
             // If we're explicity passed a URL, we'll use that.
-            array_forget($options, ['update', 'store']);
+            array_forget($options, ['model','update', 'store']);
             $options['method'] = isset($options['method']) ? $options['method'] : 'GET';
 
             return $this->form->model($model, $options);


### PR DESCRIPTION
If BootstrapForm::open() has both 'model' and 'url' set, it doesn't clear 'model' from the $options hash so the model accidentally gets toString() in the attributes, rather than removed from the $options hash beforehand. This causes a larger issue with HtmlBuilder and a 500 error.