### PR TITLE
Add the has-error class in the checkbox form-group

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -387,7 +387,7 @@ class BootstrapForm
         $wrapperOptions = $this->isHorizontal() ? ['class' => implode(' ', [$this->getLeftColumnOffsetClass(), $this->getRightColumnClass()])] : [];
         $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
 
-        return $this->getFormGroup(null, null, $wrapperElement);
+        return $this->getFormGroup($name, null, $wrapperElement);
     }
 
     /**


### PR DESCRIPTION
A checkbox field does not have the `has-error` class in its `form-group`, because we're not sending the field `$name` to the `getFormGroup()` method.