### PR TITLE
Fixed issue with laravel 5.4 - Undefined property: Illuminate\Support\MessageBag::$default

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -959,7 +959,7 @@ class BootstrapForm
         if ($this->getErrors()) {
             $allErrors = $this->config->get('bootstrap_form.show_all_errors');
 
-            $errorBag = $this->getErrors()->{$this->getErrorBag()};
+            $errorBag = $this->getErrors();
 
             if ($allErrors) {
                 return implode('', $errorBag->get($field, $format));


### PR DESCRIPTION
I didn't have time to run tests on the project, but this simple fix allows me to use this package with Laravel 5.4 normally.