### PR TITLE
Add support for input group #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,27 @@ BootForm::text('username', new Illuminate\Support\HtmlString('Username <span cla
 ### Help Text
 
 You may pass a `help_text` option to any field to have [Bootstrap Help Text](https://getbootstrap.com/css/#forms-help-text) appended to the rendered form group.
+
+### Form input group (suffix and prefix)
+
+Add prefix and/or suffix to any input, you can add text, icon and button
+
+```php
+//Suffix button with 'Call' as label and success class to button
+{!! BootForm::text('tel', 'Phone', null, ['suffix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
+
+//Prefix button with 'Call' as label and success class to button
+{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
+
+//prefix icon (I put second parameter after <i class="fa fa-SECOND_PARAMETER"></i>) with 'dollar' as icon
+{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('icon', 'dollar')] ) !!}
+
+//Prefix and suffix as text
+{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('text', '1-'), 'suffix' => BootForm::addon('icon', 'phone')] ) !!}
+
+//Prefix and suffix with button
+{!! BootForm::text('tel', 'Phone', null, ['suffix' => BootForm::addon('button', 'Boom!', ['class' => 'btn-danger']), 'prefix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
+```
+
+Options
+`'class' => this will be added to the element in group (button, icon, span)`

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -670,10 +670,7 @@ class BootstrapForm
             $class = 'input-group-addon';
             $elm = '<span ' . $this->html->attributes($options) . '><i class="fa fa-'.$label.'"></i></span>';
         }
-
-        if(isset($options['wrapper_class']))
-            $class .= $options['wrapper_class'];
-
+        
         $wrapperElement = '<div class="'.$class.'">'.$elm.'</div>';
 
         return $wrapperElement;

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -623,13 +623,60 @@ class BootstrapForm
     {
         $label = $this->getLabelTitle($label, $name);
 
-        $options = $this->getFieldOptions($options, $name);
-        $inputElement = $type === 'password' ? $this->form->password($name, $options) : $this->form->{$type}($name, $value, $options);
+        $optionsField = $this->getFieldOptions(array_except($options, ['suffix', 'prefix']), $name);
+
+        if(isset($options['prefix']) || isset($options['suffix']))
+            $this->config->set('bootstrap_form.right_column_class', $this->config->get('bootstrap_form.right_column_class'). ' input-group');
+
+        $inputElement = '';
+        if(isset($options['prefix'])) $inputElement = $options['prefix'];
+        $inputElement .= $type === 'password' ? $this->form->password($name, $optionsField) : $this->form->{$type}($name, $value, $optionsField);
+        if(isset($options['suffix'])) $inputElement .= $options['suffix'];
 
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];
-        $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $options) . '</div>';
+        $wrapperElement = '<div' . $this->html->attributes($wrapperOptions) . '>' . $inputElement . $this->getFieldError($name) . $this->getHelpText($name, $optionsField) . '</div>';
 
         return $this->getFormGroup($name, $label, $wrapperElement);
+    }
+
+    /**
+     * For suffix and prefix
+     *
+     * @param string $type
+     * @param string $label
+     * @param  array $options
+     *
+     * @return string
+     */
+    public function addon($type, $label, $options = []) {
+        $elm = '';
+        $class = '';
+
+        if($type == 'button') {
+            $class = 'input-group-btn';
+            $attr = array_merge(['class' => 'btn', 'type' => 'button'], $options);
+            if(isset($options['class']))
+                $attr['class'] .= ' btn';
+
+            $elm = '<button ' . $this->html->attributes($attr) . ' >'.$label.'</button>';
+        }
+
+        if($type == 'text') {
+            $class = 'input-group-addon';
+            $elm = '<span ' . $this->html->attributes($options) . '>'.$label.'</span>';
+        }
+
+        if($type == 'icon') {
+            $class = 'input-group-addon';
+            $elm = '<span ' . $this->html->attributes($options) . '><i class="fa fa-'.$label.'"></i></span>';
+        }
+
+        if(isset($options['wrapper_class']))
+            $class .= $options['wrapper_class'];
+
+        $wrapperElement = '<div class="'.$class.'">'.$elm.'</div>';
+
+        return $wrapperElement;
     }
 
     /**


### PR DESCRIPTION
Issues #60

Usage
```php
{!! BootForm::text('tel', 'Phone', null, ['suffix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('icon', 'dollar')] ) !!}
{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('text', '1-'), 'suffix' => BootForm::addon('icon', 'phone')] ) !!}
{!! BootForm::text('tel', 'Phone', null, ['prefix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
{!! BootForm::text('tel', 'Phone', null, ['suffix' => BootForm::addon('button', 'Boom!', ['class' => 'btn-danger']), 'prefix' => BootForm::addon('button', 'Call', ['class' => 'btn-success'])] ) !!}
```