### PR TITLE
Fix wrong wrapping of input-groups

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -632,10 +632,6 @@ class BootstrapForm
 
         $optionsField = $this->getFieldOptions(array_except($options, ['suffix', 'prefix']), $name);
 
-        if(isset($options['prefix']) || isset($options['suffix'])) {
-            $this->config->set('bootstrap_form.right_column_class', $this->config->get('bootstrap_form.right_column_class'). ' input-group');
-        }
-
         $inputElement = '';
 
         if(isset($options['prefix'])) {
@@ -646,6 +642,10 @@ class BootstrapForm
 
         if(isset($options['suffix'])) {
             $inputElement .= $options['suffix'];
+        }
+
+        if(isset($options['prefix']) || isset($options['suffix'])) {
+            $inputElement = '<div class="input-group">' . $inputElement . '</div>';
         }
 
         $wrapperOptions = $this->isHorizontal() ? ['class' => $this->getRightColumnClass()] : [];


### PR DESCRIPTION
This pull request fixes #101 and #102. With that commit input-groups with addons work in horizontal, vertial and inline forms.

<img width="700" alt="screen shot 2017-12-16 at 10 02 35" src="https://user-images.githubusercontent.com/1215125/34069037-49c761e2-e248-11e7-8186-5d9c4ae9fa67.png">
