### PR TITLE
Update BootstrapForm.php

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -48,7 +48,7 @@ class BootstrapForm
     /**
      * The error class.
      */
-    protected string $errorClass;
+    protected ?string $errorClass = null;
 
 
     /**


### PR DESCRIPTION
Prevent the error "Typed property must not be accessed before initialization" when validation errors are triggered.