### PR TITLE
Fix the ability to remove input labels.

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -569,7 +569,7 @@ class BootstrapForm
      */
     protected function getLabelTitle($label, $name)
     {
-        if ($label === false) {
+        if (!$label) {
             return null;
         }
 


### PR DESCRIPTION
Instead of checking for a `null` value - which it isn't because ` false` value is supposed to be passed to disable it - just check if the value is truthy.